### PR TITLE
make a single formats request per meeting list

### DIFF
--- a/src/app/components/meeting-list/meeting-list.component.ts
+++ b/src/app/components/meeting-list/meeting-list.component.ts
@@ -115,11 +115,7 @@ export class MeetingListComponent implements OnInit, OnChanges {
       }
     } else {
       if (this.localMeetingType === 'regular') {
-        for (let meeting of this.meetingListGroupedByDay) {
-          this.tomatoFormatsService.getFormatByID(meeting.format_shared_id_list, this.formatLanguage).then((formatData) => {
-            meeting.formats_exploded = formatData;
-          });
-        }
+        this.tomatoFormatsService.setExplodedFormatsOnMeetingList(this.meetingListGroupedByDay, this.formatLanguage);
       }
     }
   }

--- a/src/app/pages/modal/modal.page.ts
+++ b/src/app/pages/modal/modal.page.ts
@@ -34,11 +34,7 @@ export class ModalPage implements OnInit {
       }
     });
 
-    for (let meeting of this.meetingList) {
-      this.tomatoFormatsService.getFormatByID(meeting.format_shared_id_list, this.formatLanguage).then((formatData) => {
-        meeting.formats_exploded = formatData;
-      });
-    }
+    this.tomatoFormatsService.setExplodedFormatsOnMeetingList(this.meetingList, this.formatLanguage);
   }
 
   async dismiss() {
@@ -76,9 +72,6 @@ export class ModalPage implements OnInit {
 
   explodeFormats(meeting) {
     console.log("exploding formats")
-    this.tomatoFormatsService.getFormatByID(meeting.format_shared_id_list, this.formatLanguage).then((formatData) => {
-      meeting.formats_exploded = formatData;
-    });
+    this.tomatoFormatsService.setExplodedFormatsOnMeetingList([meeting], this.formatLanguage);
   }
-
 }

--- a/src/app/providers/tomato-formats.service.ts
+++ b/src/app/providers/tomato-formats.service.ts
@@ -7,32 +7,54 @@ import { HTTP } from '@ionic-native/http/ngx';
 export class TomatoFormatsService {
 
   tomatoBMLT = 'https://tomato.bmltenabled.org/main_server/client_interface/json/';
-  tomatoREST = 'https://tomato.bmltenabled.org/rest/v1/formats/';
+  tomatoREST = 'https://tomato.bmltenabled.org/rest/v1/formats/?id__in=';
 
   constructor(private httpCors: HTTP) {}
 
-  async getFormatByID(listOfIds, language) {
+  async getFormatNamesByID(uniqueIDs: Set<string>, language) {
+    const formatNamesByID = {};
+    
+    const formatsApi = this.tomatoREST + Array.from(uniqueIDs).join(",");
+    const data = await this.httpCors.get(formatsApi, {}, {});
+    const jsonData = JSON.parse(data.data);
 
-    const splitFormats = listOfIds.split(',');
-    let responseString = '';
+    for (const format of jsonData.results) {
+      const urlPieces = format.url.split("/");
+      const formatID = urlPieces[urlPieces.length - 2];
 
-    for (let format of splitFormats) {
-      const singleFormatApi = this.tomatoREST + format + '?format=json';
-      const data = await this.httpCors.get(singleFormatApi, {}, {});
-      const jsonData = JSON.parse(data.data);
-      let formatName = jsonData.translatedformats.filter(i => i.language === language);
-      if (formatName[0].name === null) {
-        formatName = jsonData.translatedformats.filter(i => i.language === 'en');
+      let formatName = format.translatedformats.filter(i => i.language === language);
+      if (formatName.length) {
+        if (formatName[0].name === undefined) {
+          formatName = format.translatedformats.filter(i => i.language === 'en');
+        }
+        if (formatName.length && formatName[0].name) {
+          formatNamesByID[formatID] = formatName[0].name;
+        }
       }
-      responseString += formatName[0].name + '. ';
     }
-    return responseString;
+
+    return formatNamesByID;
   }
 
+  setExplodedFormatsOnMeetingList(meetingList, formatLanguage) {
+    const uniqueFormatIDs = new Set<string>();
+    for (const meeting of meetingList) {
+      for (const formatID of meeting?.format_shared_id_list.split(",") || []) {
+        uniqueFormatIDs.add(formatID);
+      }
+    }
 
-  private filterByValue(array, searchString) {
-    return array.filter(o => Object.keys(o).some(k => o[k].toLowerCase().includes(searchString.toLowerCase())));
+    this.getFormatNamesByID(uniqueFormatIDs, formatLanguage).then((formatNamesByID) => {
+      for (const meeting of meetingList) {
+        let formats = '';
+        for (const formatID of meeting?.format_shared_id_list?.split(",") || []) {
+          const name = formatNamesByID[formatID];
+          if (name) {
+            formats = `${formats}${name}. `
+          }
+        }
+        meeting.formats_exploded = formats.trim();
+      }
+    });
   }
-
-
 }


### PR DESCRIPTION
Making one request per meeting per format was killing tomato. This change makes one formats request per meeting list. Tested this the best I could in the iOS emulator. Would like to get this released ASAP.