### PR TITLE
open map links in apple maps for native ios devices

### DIFF
--- a/src/app/components/meeting-card/meeting-card.component.ts
+++ b/src/app/components/meeting-card/meeting-card.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input, AfterContentInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { Capacitor } from '@capacitor/core';
 import { Browser } from '@capacitor/browser';
 import { Share } from '@capacitor/share';
 import { addHours, addMinutes, format } from 'date-fns';
@@ -90,11 +91,17 @@ export class MeetingCardComponent implements OnInit, AfterContentInit {
     });
   }
 
-
   public openMapsLink(destLatitude: string, destLongitude: string) {
-    const browser = Browser.open({url: 'https://www.google.com/maps/search/?api=1&query=' + destLatitude + ',' + destLongitude});
-  }
+    let mapsLink = `https://www.google.com/maps/search/?api=1&query=${destLatitude},${destLongitude}`;
 
+    if (Capacitor.getPlatform() === 'ios') {
+      mapsLink = `https://maps.apple.com/?daddr=${destLatitude},${destLongitude}`;
+    }
+
+    Browser.open({url: mapsLink}).catch((error: any) => {
+      console.log(error);
+    });
+  }
 
   public openLink(url: any) {
     const browser = Browser.open({url: url});

--- a/src/app/pages/modal/modal.page.ts
+++ b/src/app/pages/modal/modal.page.ts
@@ -4,6 +4,7 @@ import { NavParams, ModalController } from '@ionic/angular';
 import { Browser } from '@capacitor/browser';
 import { TomatoFormatsService } from '../../services/tomato-formats.service';
 import { StorageService } from '../../services/storage.service';
+import {Capacitor} from "@capacitor/core";
 
 @Component({
   selector: 'app-modal',
@@ -40,7 +41,15 @@ export class ModalPage implements OnInit {
   }
 
   public openMapsLink(destLatitude: string, destLongitude: string) {
-    Browser.open({url: 'https://www.google.com/maps/search/?api=1&query=' + destLatitude + ',' + destLongitude});
+    let mapsLink = `https://www.google.com/maps/search/?api=1&query=${destLatitude},${destLongitude}`;
+
+    if (Capacitor.getPlatform() === 'ios') {
+      mapsLink = `https://maps.apple.com/?daddr=${destLatitude},${destLongitude}`;
+    }
+
+    Browser.open({url: mapsLink}).catch((error: any) => {
+      console.log(error);
+    });
   }
 
   public openLink(url: any) {


### PR DESCRIPTION
Opening a google map link on an iphone opens google maps in web browser which is poor experience. This will open instead to apple maps. i'm not sure if the google ones open native google maps app on android but im just guessing they do. im sure theres a better way to do it for google with intents or geo uri but this may be good enough. 