### PR TITLE
working maps link

### DIFF
--- a/src/app/components/meeting-card/meeting-card.component.ts
+++ b/src/app/components/meeting-card/meeting-card.component.ts
@@ -93,15 +93,17 @@ export class MeetingCardComponent implements OnInit, AfterContentInit {
   }
 
   public openMapsLink(destLatitude: string, destLongitude: string) {
-    let mapsLink = `https://www.google.com/maps/search/?api=1&query=${destLatitude},${destLongitude}`;
+    const platform = Capacitor.getPlatform();
 
-    if (Capacitor.getPlatform() === 'ios') {
-      mapsLink = `https://maps.apple.com/?q=${this.meeting.meeting_name}&ll=${destLatitude},${destLongitude}`;
+    if (platform === 'ios') {
+      window.open(`maps://?daddr=${destLatitude},${destLongitude}`, '_system');
+    } else if (platform === 'android') {
+      window.open(`geo:${destLatitude},${destLongitude}?q=${destLatitude},${destLongitude}`, '_system');
+    } else {
+      Browser.open({url: `https://www.google.com/maps/search/?api=1&query=${destLatitude},${destLongitude}`}).catch((error: any) => {
+        console.log(error);
+      });
     }
-
-    Browser.open({url: mapsLink}).catch((error: any) => {
-      console.log(error);
-    });
   }
 
   public openLink(url: any) {


### PR DESCRIPTION
The maps link for iOS still isn't working properly, it's opening in the browser at maps.apple.com instead of launching the Apple Maps app.

**Root cause**: `Browser.open()` is Capacitor's in-app browser and can't dispatch native URL schemes like `maps://` to the OS. We need to use `window.open()` instead, which Capacitor routes to the OS handler on native platforms.

**The fix**: Use `window.open() `with native URL schemes (`maps:// `for iOS, `geo:` for Android) to hand off directly to the OS, which opens the native Maps app. On web, we still use `Browser.open()` with the Google Maps HTTPS link.

**Tested**: Verified on Xcode iOS Simulator, Android Studio Android Emulator, and web build, all platforms now open maps correctly.